### PR TITLE
Changed PHP 5.4 array initializers to be PHP 5.3 compatible, i.e. [] => array()

### DIFF
--- a/lib/post.php
+++ b/lib/post.php
@@ -208,7 +208,7 @@ class WordPress_GitHub_Sync_Post {
     if ( count($matches) == 2) {
       $meta = spyc_load($matches[1]);
     } else {
-      $meta = [];
+      $meta = array();
     }
 
     remove_action( 'save_post', array( &$wpghs, 'push_post' ) );

--- a/wordpress-github-sync.php
+++ b/wordpress-github-sync.php
@@ -150,9 +150,7 @@ class WordPress_GitHub_Sync {
       if ( $nwo != $this->repository() )
         wp_die( $nwo . __(" is an invalid repository", WordPress_GitHub_Sync::$text_domain) );
 
-      $modified = [];
-      $added = [];
-      $removed = [];
+      $modified = $added = $removed = array();
 
       foreach ($data->commits as $commit) {
         $modified = array_merge( $modified, $commit->modified );
@@ -184,7 +182,7 @@ class WordPress_GitHub_Sync {
 
       // Nginx and pre 5.4 workaround
       // http://www.php.net/manual/en/function.getallheaders.php
-      $headers = [];
+      $headers = array();
       foreach ($_SERVER as $name => $value) {
        if (substr($name, 0, 5) == 'HTTP_') {
          $headers[str_replace(' ', '-', ucwords(strtolower(str_replace('_', ' ', substr($name, 5)))))] = $value;


### PR DESCRIPTION
Hi Ben,

Not sure if you want to make Github Sync compatible with PHP 5.3 or not but since I still use 5.3 at times I've found it doesn't work because of the array initializers.  I've fixed it to work with PHP 5.3, at least for array initializers with this branch and pull request.
