### PR TITLE
Composer setup for SPYC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+vendor/
+composer.lock

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,16 @@
+{
+	"name": "benbalter/wordpress-github-sync",
+	"description": "A WordPress plugin to sync content with a GitHub repository (or Jekyll site)",
+	"minimum-stability": "stable",
+	"license": "GPL",
+	"authors": [
+		{
+			"name": "Ben Balter",
+			"email": "ben@balter.com"
+		}
+	],
+	"require": {
+        "php": ">=5.3.1",
+        "mustangostang/spyc": "*"
+    }
+}


### PR DESCRIPTION
Ref #17 Install path ends up wordpress-github-sync/vendor/mustangostang/spyc
Do you want the vendor directory pushed also. It's usually not.
See: https://getcomposer.org/doc/faqs/should-i-commit-the-dependencies-in-my-vendor-directory.md
