### PR TITLE
Use hubot.github.com, rather than my personal site as an example

### DIFF
--- a/lib/admin.php
+++ b/lib/admin.php
@@ -48,7 +48,7 @@ class WordPress_GitHub_Sync_Admin {
 		add_settings_field( 'wpghs_repository', __( 'Repository', 'wordpress-github-sync' ), array( $this, 'field_callback' ), WordPress_GitHub_Sync::$text_domain, 'general', array(
 				'default'   => '',
 				'name'      => 'wpghs_repository',
-				'help_text' => __( 'The GitHub repository to commit to, with owner (<code>[OWNER]/[REPOSITORY]</code>), e.g., <code>benbalter/benbalter.github.com</code>. The repository should contain an initial commit.', 'wordpress-github-sync' ),
+				'help_text' => __( 'The GitHub repository to commit to, with owner (<code>[OWNER]/[REPOSITORY]</code>), e.g., <code>github/hubot.github.com</code>. The repository should contain an initial commit.', 'wordpress-github-sync' ),
 			)
 		);
 


### PR DESCRIPTION
Not that I don't :heart: the plugin, but it just felt a little vain. I'm open to suggestions for another example domain if you have any.