### PR TITLE
Run meta data through maybe_unserialize()

### DIFF
--- a/lib/post.php
+++ b/lib/post.php
@@ -331,10 +331,10 @@ class WordPress_GitHub_Sync_Post {
 			'published'    => 'publish' === $this->status() ? true : false,
 		);
 
-		//convert traditional post_meta values, hide hidden values
+		//convert traditional post_meta values, hide hidden values, skip already populated values
 		foreach ( get_post_custom( $this->id ) as $key => $value ) {
 
-			if ( '_' === substr( $key, 0, 1 ) ) {
+			if ( '_' === substr( $key, 0, 1 ) || isset( $meta[ $key ] ) ) {
 				continue;
 			}
 


### PR DESCRIPTION
Run meta data through `maybe_unserialize()` as `get_post_custom()` can potentially return serialized data.

See: @link https://codex.wordpress.org/Function_Reference/get_post_custom