### PR TITLE
Changed message to user to show import from github

### DIFF
--- a/lib/admin.php
+++ b/lib/admin.php
@@ -126,21 +126,21 @@ class WordPress_GitHub_Sync_Admin {
 
 		if ( 'yes' === get_option( '_wpghs_import_started' ) ) { ?>
 			<div class="updated">
-			<p><?php esc_html_e( 'Import to GitHub started.', 'wordpress-github-sync' ); ?></p>
+			<p><?php esc_html_e( 'Import from GitHub started.', 'wordpress-github-sync' ); ?></p>
 			</div><?php
 			delete_option( '_wpghs_import_started' );
 		}
 
 		if ( $message = get_option( '_wpghs_import_error' ) ) { ?>
 			<div class="error">
-			<p><?php esc_html_e( 'Import to GitHub failed with error:', 'wordpress-github-sync' ); ?> <?php echo esc_html( $message );?></p>
+			<p><?php esc_html_e( 'Import from GitHub failed with error:', 'wordpress-github-sync' ); ?> <?php echo esc_html( $message );?></p>
 			</div><?php
 			delete_option( '_wpghs_import_error' );
 		}
 
 		if ( 'yes' === get_option( '_wpghs_import_complete' ) ) { ?>
 			<div class="updated">
-			<p><?php esc_html_e( 'Import to GitHub completed successfully.', 'wordpress-github-sync' );?></p>
+			<p><?php esc_html_e( 'Import from GitHub completed successfully.', 'wordpress-github-sync' );?></p>
 			</div><?php
 			delete_option( '_wpghs_import_complete' );
 		}


### PR DESCRIPTION
Changed the message shown to users from "Import to github" to be "Import from Github" as you are actually importing FROM github TO wordpress.