### PR TITLE
Only send body when making GET request

### DIFF
--- a/lib/client/base.php
+++ b/lib/client/base.php
@@ -48,10 +48,13 @@ class WordPress_GitHub_Sync_Base_Client {
 			'headers' => array(
 				'Authorization' => 'token ' . $this->oauth_token(),
 			),
-			'body'    => function_exists( 'wp_json_encode' ) ?
-				wp_json_encode( $body ) :
-				json_encode( $body ),
 		);
+
+		if ( 'GET' !== $method ) {
+			$args['body'] = function_exists( 'wp_json_encode' ) ?
+				wp_json_encode( $body ) :
+				json_encode( $body );
+		}
 
 		$response = wp_remote_request( $endpoint, $args );
 		$status   = wp_remote_retrieve_header( $response, 'status' );

--- a/tests/unit/client/test-base.php
+++ b/tests/unit/client/test-base.php
@@ -81,7 +81,7 @@ abstract class WordPress_GitHub_Sync_Base_Client_Test extends WordPress_GitHub_S
 	protected function set_get_refs_heads_master( $succeed ) {
 		$this->set_endpoint(
 			function ( $request ) {
-				if ( '[]' !== $request['body'] ) {
+				if ( '[]' === $request['body'] ) {
 					return false;
 				}
 
@@ -93,7 +93,7 @@ abstract class WordPress_GitHub_Sync_Base_Client_Test extends WordPress_GitHub_S
 	protected function set_get_commits( $succeed ) {
 		$this->set_endpoint(
 			function ( $request ) {
-				if ( '[]' !== $request['body'] ) {
+				if ( '[]' === $request['body'] ) {
 					return false;
 				}
 
@@ -105,7 +105,7 @@ abstract class WordPress_GitHub_Sync_Base_Client_Test extends WordPress_GitHub_S
 	protected function set_get_trees( $succeed ) {
 		$this->set_endpoint(
 			function ( $request ) {
-				if ( '[]' !== $request['body'] ) {
+				if ( '[]' === $request['body'] ) {
 					return false;
 				}
 
@@ -124,7 +124,7 @@ abstract class WordPress_GitHub_Sync_Base_Client_Test extends WordPress_GitHub_S
 		foreach ( $shas as $sha ) {
 			$this->set_endpoint(
 				function ( $request ) {
-					if ( '[]' !== $request['body'] ) {
+					if ( '[]' === $request['body'] ) {
 						return false;
 					}
 


### PR DESCRIPTION
Including a body with a GET to the new Requests library throws a
warning. This ensures we don't include the `body` as an argument for
GET requests.

Fixes #149.