### PR TITLE
Allow customizations when importing posts

### DIFF
--- a/lib/database.php
+++ b/lib/database.php
@@ -152,7 +152,10 @@ class WordPress_GitHub_Sync_Database {
 		 */
 		$error = false;
 
+		do_action( 'wpghs_pre_save_loop_action' );
+
 		foreach ( $posts as $post ) {
+			do_action( 'wpghs_pre_save_action', $post );
 			$args    = apply_filters( 'wpghs_pre_import_args', $post->get_args(), $post );
 			
 			remove_filter('content_save_pre', 'wp_filter_post_kses');
@@ -186,6 +189,7 @@ class WordPress_GitHub_Sync_Database {
 				update_post_meta( $post_id, $key, $value );
 			}
 		}
+		do_action( 'wpghs_post_save_loop_action' );
 
 		if ( $error ) {
 			return $error;


### PR DESCRIPTION
The three actions that this adds allow us to do initializations
before all the posts are saved, then post-specific modifications
for each post before it gets saved, and finally we can restore
settings after all the posts are saved.

This was needed in order to be able to track the current language
used in WPML, then set the active language for each post (because
otherwise post categories would get deleted), and finally reset
the active lanugage to the one remembered in the first action.

See #164 

Signed-off-by: Dirk Hohndel <dirk@hohndel.org>