### PR TITLE
Only update posts that are marked as modified

### DIFF
--- a/lib/import.php
+++ b/lib/import.php
@@ -41,8 +41,8 @@ class WordPress_GitHub_Sync_Import {
 		 */
 		$error = false;
 
-		$head_commit = $payload->get_commit();
-		$result = $this->commit( $this->app->api()->fetch()->commit( $payload->get_commit_id() ), $head_commit );
+		$commits = $payload->get_commits();
+		$result = $this->commit( $this->app->api()->fetch()->commit( $payload->get_commit_id() ), $commits );
 
 		if ( is_wp_error( $result ) ) {
 			$error = $result;
@@ -87,15 +87,17 @@ class WordPress_GitHub_Sync_Import {
 	 *
 	 * @return string|WP_Error
 	 */
-	protected function commit( $commit , $head_commit_obj) {
+	protected function commit( $commit , $commits_array) {
 		$head_commit = array();
 		$mod_files = array();
 		$update_all = true;
-		if ( $head_commit_obj != null ) {
-			$head_commit = json_decode(json_encode($head_commit_obj), true);
-			if ( array_key_exists( 'modified', $head_commit ) ) {
-				$mod_files = $head_commit['modified'];
-				$update_all = false;
+		foreach ( $commits_array as $commit_obj ) {
+			if ( $commit_obj != null ) {
+				$next_commit = json_decode(json_encode($commit_obj), true);
+				if ( array_key_exists( 'modified', $next_commit ) ) {
+					$mod_files = array_merge($mod_files, $next_commit['modified']);
+					$update_all = false;
+				}
 			}
 		}
 

--- a/lib/import.php
+++ b/lib/import.php
@@ -41,7 +41,8 @@ class WordPress_GitHub_Sync_Import {
 		 */
 		$error = false;
 
-		$result = $this->commit( $this->app->api()->fetch()->commit( $payload->get_commit_id() ) );
+		$head_commit = $payload->get_commit();
+		$result = $this->commit( $this->app->api()->fetch()->commit( $payload->get_commit_id() ), $head_commit );
 
 		if ( is_wp_error( $result ) ) {
 			$error = $result;
@@ -76,7 +77,7 @@ class WordPress_GitHub_Sync_Import {
 	 * @return string|WP_Error
 	 */
 	public function master() {
-		return $this->commit( $this->app->api()->fetch()->master() );
+		return $this->commit( $this->app->api()->fetch()->master(), null );
 	}
 
 	/**
@@ -86,7 +87,18 @@ class WordPress_GitHub_Sync_Import {
 	 *
 	 * @return string|WP_Error
 	 */
-	protected function commit( $commit ) {
+	protected function commit( $commit , $head_commit_obj) {
+		$head_commit = array();
+		$mod_files = array();
+		$update_all = true;
+		if ( $head_commit_obj != null ) {
+			$head_commit = json_decode(json_encode($head_commit_obj), true);
+			if ( array_key_exists( 'modified', $head_commit ) ) {
+				$mod_files = $head_commit['modified'];
+				$update_all = false;
+			}
+		}
+
 		if ( is_wp_error( $commit ) ) {
 			return $commit;
 		}
@@ -103,10 +115,20 @@ class WordPress_GitHub_Sync_Import {
 				continue;
 			}
 
-			$posts[] = $post = $this->blob_to_post( $blob );
+			$post = $this->blob_to_post( $blob );
+
+			$found = $update_all;
+			foreach ( $mod_files as $modified_file ) {
+				if ($blob->path() == $modified_file) {
+					$found = true;
+				}
+			}
 
 			if ( $post->is_new() ) {
+				$posts[] = $post;
 				$new[] = $post;
+			} elseif ( $found ) {
+				$posts[] = $post;
 			}
 		}
 

--- a/lib/payload.php
+++ b/lib/payload.php
@@ -77,15 +77,6 @@ class WordPress_GitHub_Sync_Payload {
 	}
 
 	/**
-	 * Returns the head commit.
-	 *
-	 * @return string
-	 */
-	public function get_commit() {
-		return $this->data->head_commit;
-	}
-
-	/**
 	 * Returns the sha of the head commit.
 	 *
 	 * @return string

--- a/lib/payload.php
+++ b/lib/payload.php
@@ -77,6 +77,15 @@ class WordPress_GitHub_Sync_Payload {
 	}
 
 	/**
+	 * Returns the head commit.
+	 *
+	 * @return string
+	 */
+	public function get_commit() {
+		return $this->data->head_commit;
+	}
+
+	/**
 	 * Returns the sha of the head commit.
 	 *
 	 * @return string


### PR DESCRIPTION
Github tells us which files were modified. If we find that information in the
webhook callback, let's not blindly update all posts but instead only update
those posts that we were told were modified.

This adds a new function to the payload class to get the actual head commit
included in the payload.

json_decode(json_encode(), true) is used to convert the object to an array -
I'm not sure if there is a different way that you would like to use for this
(I'm not really a PHP developer - but this works).

Signed-off-by: Dirk Hohndel <dirk@hohndel.org>