### PR TITLE
Hide "Edit this page on Github" in blog feeds

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ All four of these functions must be used in the loop. If you'd like to retrieve 
 If you'd like to include an edit link without modifying your theme directly, you can add one of these functions to `the_content` like so:
 
     add_filter( 'the_content', function( $content ) {
-      if( is_page() || is_single() ) {
+      if ( get_post_type() == 'post' && ( ! in_array( 'get_the_excerpt', $GLOBALS['wp_current_filter'] )) ) {
         $content .= get_the_github_edit_link();
       }
       return $content;


### PR DESCRIPTION
**Problem:** In my theme ("Hestia Pro" from Themeisle.com), the string "Edit this page on Github" is displayed also in blog feeds/previews of blog posts. In a feed, for each article,
  - an article's featured image is shown, 
  - an excerpt of the post below,
  - and the excerpt always just ends with "Edit this page on Github" (as string, without a hyperlink). 

This is probably not intended in general. It's caused by the edited function that adds the string to the content on blog posts (`is_single`) and pages (`is_page`), which for me also includes feeds.

**Solution:** This PR hides the string "Edit on Github" on blog feeds. However, it also hides this string on pages! This  is fine in my use case, but might not be fine for others. You probably also want to find a way to show the string on pages again and present both ways for users in the README.

To show the string on pages again, I tried to add `is_page()` to the if clause, but was not successful. I leav it to you.

(BTW I love this plugin, it works very well so far!)