### PR TITLE
Remove handling of custom post meta

### DIFF
--- a/lib/post.php
+++ b/lib/post.php
@@ -331,17 +331,6 @@ class WordPress_GitHub_Sync_Post {
 			'published'    => 'publish' === $this->status() ? true : false,
 		);
 
-		//convert traditional post_meta values, hide hidden values, skip already populated values
-		foreach ( get_post_custom( $this->id ) as $key => $value ) {
-
-			if ( '_' === substr( $key, 0, 1 ) || isset( $meta[ $key ] ) ) {
-				continue;
-			}
-
-			$meta[ $key ] = $value;
-
-		}
-
 		return apply_filters( 'wpghs_post_meta', $meta, $this );
 	}
 


### PR DESCRIPTION
It's not possible to handle this consistently across all possible
meta structures, so remove any handling from WPGHS and
force userland to handle this explicitly, based on the way they
need to edit, import, and export the post meta.

Fixes #159 & #171.