### PR TITLE
Use sanitize_file_name instead of sanitize_title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This change log follows the [Keep a Changelog standards][]. Versions follows [Se
 
 * **POSSIBLY BREAKING**: Remove handling of custom post meta
     * If you were relying on WPGHS to export custom post meta, use `wpghs_post_meta` filter & `wpghs_pre_import_meta` to handle the meta yourself. See the [documentation][] for more information.
+* Switch from `sanitize_title` to `sanitize_file_name`.
+    * This should ensure better fidelity to the original filename.
 
 ### [1.7.5][] ###
 

--- a/lib/post.php
+++ b/lib/post.php
@@ -210,6 +210,8 @@ class WordPress_GitHub_Sync_Post {
 			$filename = $this->get_name() . '.md';
 		}
 
+		$filename = sanitize_file_name( $filename );
+
 		return apply_filters( 'wpghs_filename', $filename, $this );
 	}
 
@@ -223,7 +225,7 @@ class WordPress_GitHub_Sync_Post {
 			return $this->name();
 		}
 
-		return sanitize_title( get_the_title( $this->post ) );
+		return get_the_title( $this->post );
 	}
 
 	/**


### PR DESCRIPTION
The latter urlencodes the filename, which is not appropriate
for what we're working with.

Fixes #160.