### PR TITLE
Only export `post_date` if post is published

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This change log follows the [Keep a Changelog standards][]. Versions follows [Se
     * If you were relying on WPGHS to export custom post meta, use `wpghs_post_meta` filter & `wpghs_pre_import_meta` to handle the meta yourself. See the [documentation][] for more information.
 * Switch from `sanitize_title` to `sanitize_file_name`.
     * This should ensure better fidelity to the original filename.
+* Don't export `post_date` if post isn't published.
+    * `post_date` means the time the post was published. If it's not published, it shouldn't have a `post_date`.
 
 ### [1.7.5][] ###
 

--- a/lib/post.php
+++ b/lib/post.php
@@ -326,12 +326,16 @@ class WordPress_GitHub_Sync_Post {
 			'ID'           => $this->post->ID,
 			'post_title'   => get_the_title( $this->post ),
 			'author'       => ( $author = get_userdata( $this->post->post_author ) ) ? $author->display_name : '',
-			'post_date'    => $this->post->post_date,
 			'post_excerpt' => $this->post->post_excerpt,
 			'layout'       => get_post_type( $this->post ),
 			'permalink'    => get_permalink( $this->post ),
 			'published'    => 'publish' === $this->status() ? true : false,
 		);
+
+		// only include the post date if the post is published
+		if ( $meta['published'] ) {
+			$meta['post_date'] = $this->post->post_date;
+		}
 
 		return apply_filters( 'wpghs_post_meta', $meta, $this );
 	}


### PR DESCRIPTION
`post_date` means the time the post was published. If it's not
published, it shouldn't have a `post_date`.

Fix #140.