### PR TITLE
Set post_date from imported blob

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This change log follows the [Keep a Changelog standards][]. Versions follows [Se
     * This should ensure better fidelity to the original filename.
 * Don't export `post_date` if post isn't published.
     * `post_date` means the time the post was published. If it's not published, it shouldn't have a `post_date`.
+* Overwrite post_date from markdown, allowing remote user to modify publish date.
 
 ### [1.7.5][] ###
 

--- a/lib/import.php
+++ b/lib/import.php
@@ -185,6 +185,12 @@ class WordPress_GitHub_Sync_Import {
 				$args['ID'] = $meta['ID'];
 				unset( $meta['ID'] );
 			}
+
+			if ( array_key_exists( 'post_date', $meta ) ) {
+				$args['post_date'] = $meta['post_date'];
+				$args['post_date_gmt'] = get_gmt_from_date( $meta['post_date'] );
+				unset( $meta['post_date'] );
+			}
 		}
 
 		$meta['_sha'] = $blob->sha();


### PR DESCRIPTION
This also sets the post_date_gmt because WordPress does
not handle this on its own.

Fixes #181.