### PR TITLE
Fix JSON decode and empty post_date

### DIFF
--- a/lib/import.php
+++ b/lib/import.php
@@ -187,11 +187,12 @@ class WordPress_GitHub_Sync_Import {
 			}
 
 			if ( array_key_exists( 'post_date', $meta ) ) {
-				$args['post_date'] = $meta['post_date'];
 
 				if ( empty( $meta['post_date'] ) ) {
 					$meta['post_date'] = current_time( 'mysql' );
 				}
+
+				$args['post_date'] = $meta['post_date'];
 
 				$args['post_date_gmt'] = get_gmt_from_date( $meta['post_date'] );
 				unset( $meta['post_date'] );

--- a/lib/import.php
+++ b/lib/import.php
@@ -188,6 +188,11 @@ class WordPress_GitHub_Sync_Import {
 
 			if ( array_key_exists( 'post_date', $meta ) ) {
 				$args['post_date'] = $meta['post_date'];
+
+				if ( empty( $meta['post_date'] ) ) {
+					$meta['post_date'] = current_time( 'mysql' );
+				}
+
 				$args['post_date_gmt'] = get_gmt_from_date( $meta['post_date'] );
 				unset( $meta['post_date'] );
 			}

--- a/lib/payload.php
+++ b/lib/payload.php
@@ -40,6 +40,10 @@ class WordPress_GitHub_Sync_Payload {
 		$this->app  = $app;
 
 		$this->data = $this->get_payload_from_raw_response( $raw_data );
+		if ( false === $this->data ) {
+			// Bail here, error message is already set in the method above.
+			return;
+		}
 
 		if ( null === $this->data ) {
 			switch ( json_last_error() ) {

--- a/lib/payload.php
+++ b/lib/payload.php
@@ -38,12 +38,7 @@ class WordPress_GitHub_Sync_Payload {
 	 */
 	public function __construct( WordPress_GitHub_Sync $app, $raw_data ) {
 		$this->app  = $app;
-
 		$this->data = $this->get_payload_from_raw_response( $raw_data );
-		if ( false === $this->data ) {
-			// Bail here, error message is already set in the method above.
-			return;
-		}
 
 		if ( null === $this->data ) {
 			switch ( json_last_error() ) {
@@ -77,7 +72,7 @@ class WordPress_GitHub_Sync_Payload {
 	 *
 	 * @see    WordPress_GitHub_Sync_Request::read_raw_data()
 	 *
-	 * @return Object|false An object from JSON Decode or false if failure.
+	 * @return Object|null An object from JSON Decode or false if failure.
 	 *
 	 * @author JayWood <jjwood2004@gmail.com>
 	 */
@@ -99,8 +94,7 @@ class WordPress_GitHub_Sync_Payload {
 		parse_str( $raw_data, $decoded_data );
 
 		if ( ! isset( $decoded_data['payload'] ) ) {
-			$this->error = __( 'No payload available from GH response.', 'wp-github-sync' );
-			return false;
+			return null;
 		}
 
 		return json_decode( $decoded_data['payload'] );


### PR DESCRIPTION
This fixes #185 

Two issues here.

When the payload comes from GitHub you have to `parse_str` on the raw data and then access the `payload` key, that is what retains the JSON.  However, in the interest of backwards compatibility I left the same old method there, but only ran the new method if it failed.

As for the date - it was due to the `post_date` being empty prior to being passed to `get_gmt_from_date` so now if it's empty, but is still set, we will now use `current_time()` to get the WordPress time during import, and no longer pass an empty string to the GMT function.